### PR TITLE
Use Github Actions to build on Linux ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [aarch64]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/trf" 
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y automake make gcc file
+        run: |
+          cd /trf
+          mkdir -p build && cd build
+          ../configure
+          make install
+          ls -laR
+          file ./src/trf
+          ./src/trf ../t/test_seqs.fasta 2 5 7 80 10 50 2000 -l 10


### PR DESCRIPTION
Hello,

I came here because I need to build gridss on Linux ARM64 - https://github.com/PapenfussLab/gridss/issues/592.
One of its dependencies is TRF - https://github.com/PapenfussLab/gridss/blob/68a06659dee28dae7979e5584d6e2c275f270faf/Dockerfile#L96
Currently TRF does not provide ARM64 (linux_aarch64) binary - https://github.com/Benson-Genomics-Lab/TRF/releases/tag/v4.09.1

I've noticed https://github.com/Benson-Genomics-Lab/TRF/issues/1 that mentions problems with some tests on Linux ARM64.

This PR introduces CI on Linux ARM64 by using Github Actions and QEMU emulation.
Please let me know what you think and what else would be needed to add linux_aarch64 to the released binaries !